### PR TITLE
make jlpcb file generation automatic

### DIFF
--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -18,10 +18,14 @@ jobs:
     - uses: actions/checkout@v2
     - uses: INTI-CMNB/KiBot@v2_k6
       with:
-        # Required - kibot config file
+        # kibot config file
         config: config.kibot.yaml
-        # optional - prefix to output defined in config
+        # prefix to output defined in config
         dir: output
+        # schematic file
+        # schema: 'versions/v0.1/CCC_ESC.kicad_sch'
+        # PCB design file
+        board: 'versions/v0.1/CCC_ESC.kicad_pcb'
     - name: upload results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -1,6 +1,7 @@
 name: kibot
 
 on:
+  workflow_dispatch:
   push:
     paths:
     - '**.sch'

--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -23,7 +23,7 @@ jobs:
         # prefix to output defined in config
         dir: output
         # schematic file
-        # schema: 'versions/v0.1/CCC_ESC.kicad_sch'
+        schema: 'versions/v0.1/CCC_ESC.kicad_sch'
         # PCB design file
         board: 'versions/v0.1/CCC_ESC.kicad_pcb'
     - name: upload results

--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -1,0 +1,28 @@
+name: kibot
+
+on:
+  push:
+    paths:
+    - '**.sch'
+    - '**.kicad_pcb'
+  pull_request:
+    paths:
+      - '**.sch'
+      - '**.kicad_pcb'
+
+jobs:
+  kibot:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: INTI-CMNB/KiBot@v2_k6
+      with:
+        # Required - kibot config file
+        config: config.kibot.yaml
+        # optional - prefix to output defined in config
+        dir: output
+    - name: upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: output
+        path: output

--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -29,5 +29,5 @@ jobs:
     - name: upload results
       uses: actions/upload-artifact@v2
       with:
-        name: MP2_ESC
-        path: output
+        name: MP2_ESC_JLCPCB
+        path: JLCPCB

--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -29,5 +29,5 @@ jobs:
     - name: upload results
       uses: actions/upload-artifact@v2
       with:
-        name: output
+        name: MP2_ESC
         path: output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         # PCB design file
         board: 'versions/v0.1/CCC_ESC.kicad_pcb'
     - name: list results
-      run: 'ls JLCPCB'
+      run: 'ls -R -l'
     - name: upload results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
   push:
     paths:
-    - '**.sch'
-    - '**.kicad_pcb'
+    - '*.sch'
+    - '*.kicad_pcb'
+    - '*.kibot.yaml'
+    - '.github/workflows/main.yml'
   pull_request:
     paths:
-      - '**.sch'
-      - '**.kicad_pcb'
+    - '*.sch'
+    - '*.kicad_pcb'
+    - '*.kibot.yaml'
+    - '.github/workflows/main.yml'
 
 jobs:
   kibot:
@@ -26,8 +30,14 @@ jobs:
         schema: 'versions/v0.1/CCC_ESC.kicad_sch'
         # PCB design file
         board: 'versions/v0.1/CCC_ESC.kicad_pcb'
+    - name: list results
+        run: ls JLCPCB
     - name: upload results
       uses: actions/upload-artifact@v2
       with:
         name: MP2_ESC_JLCPCB
-        path: JLCPCB
+        path: |
+          JLCPCB/JLCPCB_gerbers.zip
+          JLCPCB/JLCPCB_drill.zip
+          JLCPCB/JLCPCB_position.zip
+          JLCPCB/JLCPCB_bom.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         # PCB design file
         board: 'versions/v0.1/CCC_ESC.kicad_pcb'
     - name: list results
-        run: ls JLCPCB
+      run: 'ls JLCPCB'
     - name: upload results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: MP2_ESC_JLCPCB
-        path: |
-          JLCPCB/JLCPCB_gerbers.zip
-          JLCPCB/JLCPCB_drill.zip
-          JLCPCB/JLCPCB_position.zip
-          JLCPCB/JLCPCB_bom.zip
+        path: './output/JLCPCB/CCC_ESC-JLCPCB.zip'

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -1,45 +1,82 @@
+# Gerber and drill files for JLCPCB, without stencil
+# URL: https://jlcpcb.com/
+# Based on setting used by Gerber Zipper (https://github.com/g200kg/kicad-gerberzipper)
 kibot:
   version: 1
 
 filters:
   - name: only_jlc_parts
-    comment: 'Only parts with JLC code'
+    comment: 'Only parts with JLC (LCSC) code'
     type: generic
     include_only:
       - column: 'LCSC#'
         regex: '^C\d+'
 
+variants:
+  - name: rotated
+    comment: 'Just a place holder for the rotation filter'
+    type: kibom
+    variant: rotated
+    pre_transform: _rot_footprint
+
 outputs:
-  - name: 'gerbers'
-    comment: "Gerbers for the ESC"
+  - name: JLCPCB_gerbers
+    comment: Gerbers compatible with JLCPCB
     type: gerber
-    dir: gerberdir
-    options:
-      # generic layer options
-      exclude_edge_layer: false
-      exclude_pads_from_silkscreen: false
+    dir: JLCPCB
+    options: &gerber_options
+      exclude_edge_layer: true
+      exclude_pads_from_silkscreen: true
       plot_sheet_reference: false
       plot_footprint_refs: true
-      plot_footprint_values: true
+      plot_footprint_values: false
       force_plot_invisible_refs_vals: false
       tent_vias: true
-      line_width: 0.15
-
-      # gerber options
-      use_aux_axis_as_origin: false
-      subtract_mask_from_silk: true
-      use_protel_extensions: false
-      gerber_precision: 4.5
-      create_gerber_job_file: true
-      use_gerber_x2_attributes: true
+      use_protel_extensions: true
+      create_gerber_job_file: false
+      disable_aperture_macros: true
+      gerber_precision: 4.6
+      use_gerber_x2_attributes: false
       use_gerber_net_attributes: false
+      line_width: 0.1
+      subtract_mask_from_silk: true
+      inner_extension_pattern: '.gp%n'
+    layers:
+      # Note: a more generic approach is to use 'copper' but then the filenames
+      # are slightly different.
+      - F.Cu
+      - B.Cu
+      - In1.Cu
+      - In2.Cu
+      - In3.Cu
+      - In4.Cu
+      - In5.Cu
+      - In6.Cu
+      - F.SilkS
+      - B.SilkS
+      - F.Mask
+      - B.Mask
+      - Edge.Cuts
 
-    layers: 'selected'
-  
-  - name: 'position'
-    comment: "Pick and place file, JLC style"
-    type: position
+  - name: JLCPCB_drill
+    comment: Drill files compatible with JLCPCB
+    type: excellon
+    dir: JLCPCB
     options:
+      pth_and_npth_single_file: false
+      pth_id: '-PTH'
+      npth_id: '-NPTH'
+      metric_units: true
+      map: gerber
+      route_mode_for_oval_holes: false
+      output: "%f%i.%x"
+
+  - name: 'JLCPCB_position'
+    comment: "Pick and place file, JLCPCB style"
+    type: position
+    dir: JLCPCB
+    options:
+      variant: rotated
       output: '%f_cpl_jlc.%x'
       format: CSV
       units: millimeters
@@ -59,22 +96,38 @@ outputs:
         - id: Side
           name: Layer
 
-  # - name: 'bom'
-  #   comment: "BoM for JLC"
-  #   type: bom
-  #   options:
-  #     output: '%f_%i_jlc.%x'
-  #     exclude_filter: 'only_jlc_parts'
-  #     ref_separator: ','
-  #     columns:
-  #       - field: Value
-  #         name: Comment
-  #       - field: References
-  #         name: Designator
-  #       - Footprint
-  #       - field: 'LCSC#'
-  #         name: 'LCSC Part #'
-  #     csv:
-  #       hide_pcb_info: true
-  #       hide_stats_info: true
-  #       quote_all: true
+  - name: 'JLCPCB_bom'
+    comment: "BoM for JLCPCB"
+    type: bom
+    dir: JLCPCB
+    options:
+      output: '%f_%i_jlc.%x'
+      exclude_filter: 'only_jlc_parts'
+      ref_separator: ','
+      columns:
+        - field: Value
+          name: Comment
+        - field: References
+          name: Designator
+        - Footprint
+        - field: 'LCSC#'
+          name: 'LCSC Part #'
+      csv:
+        hide_pcb_info: true
+        hide_stats_info: true
+        quote_all: true
+
+  - name: JLCPCB
+    comment: ZIP file for JLCPCB
+    type: compress
+    dir: JLCPCB
+    options:
+      files:
+        - from_output: JLCPCB_gerbers
+          dest: /
+        - from_output: JLCPCB_drill
+          dest: /
+        - from_output: JLCPCB_position
+          dest: /
+        - from_output: JLCPCB_bom
+          dest: /

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -9,7 +9,7 @@ filters:
     comment: 'Only parts with JLC (LCSC) code'
     type: generic
     include_only:
-      - column: 'LCSC#'
+      - column: 'LCSC'
         regex: '^C\d+'
 
 variants:
@@ -87,6 +87,7 @@ outputs:
     dir: JLCPCB
     options:
       output: '%f_%i_jlc.%x'
+      exclude_filter: 'only_jlc_parts'
       ref_separator: ','
       columns:
         - field: Value
@@ -94,7 +95,7 @@ outputs:
         - field: References
           name: Designator
         - Footprint
-        - field: 'LCSC#'
+        - field: 'LCSC'
           name: 'LCSC Part #'
       csv:
         hide_pcb_info: true

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -96,26 +96,26 @@ outputs:
         - id: Side
           name: Layer
 
-  - name: 'JLCPCB_bom'
-    comment: "BoM for JLCPCB"
-    type: bom
-    dir: JLCPCB
-    options:
-      output: '%f_%i_jlc.%x'
-      exclude_filter: 'only_jlc_parts'
-      ref_separator: ','
-      columns:
-        - field: Value
-          name: Comment
-        - field: References
-          name: Designator
-        - Footprint
-        - field: 'LCSC#'
-          name: 'LCSC Part #'
-      csv:
-        hide_pcb_info: true
-        hide_stats_info: true
-        quote_all: true
+  # - name: 'JLCPCB_bom'
+  #   comment: "BoM for JLCPCB"
+  #   type: bom
+  #   dir: JLCPCB
+  #   options:
+  #     output: '%f_%i_jlc.%x'
+  #     exclude_filter: 'only_jlc_parts'
+  #     ref_separator: ','
+  #     columns:
+  #       - field: Value
+  #         name: Comment
+  #       - field: References
+  #         name: Designator
+  #       - Footprint
+  #       - field: 'LCSC#'
+  #         name: 'LCSC Part #'
+  #     csv:
+  #       hide_pcb_info: true
+  #       hide_stats_info: true
+  #       quote_all: true
 
   - name: JLCPCB
     comment: ZIP file for JLCPCB
@@ -129,5 +129,5 @@ outputs:
           dest: /
         - from_output: JLCPCB_position
           dest: /
-        - from_output: JLCPCB_bom
-          dest: /
+        # - from_output: JLCPCB_bom
+        #   dest: /

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -1,9 +1,6 @@
 kibot:
   version: 1
 
-preflight:
-  run_drc: true
-
 outputs:
   - name: 'gerbers'
     comment: "Gerbers for the ESC"

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -5,7 +5,6 @@ preflight:
   run_drc: true
 
 outputs:
-
   - name: 'gerbers'
     comment: "Gerbers for the ESC"
     type: gerber
@@ -30,6 +29,4 @@ outputs:
       use_gerber_x2_attributes: true
       use_gerber_net_attributes: false
 
-    layers:
-      - 'F.Cu'
-      - 'B.Cu'
+    layers: 'all'

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -58,18 +58,18 @@ outputs:
       - B.Mask
       - Edge.Cuts
 
-  # - name: JLCPCB_drill
-  #   comment: Drill files compatible with JLCPCB
-  #   type: excellon
-  #   dir: JLCPCB
-  #   options:
-  #     pth_and_npth_single_file: false
-  #     pth_id: '-PTH'
-  #     npth_id: '-NPTH'
-  #     metric_units: true
-  #     map: gerber
-  #     route_mode_for_oval_holes: false
-  #     output: "%f%i.%x"
+  - name: JLCPCB_drill
+    comment: Drill files compatible with JLCPCB
+    type: excellon
+    dir: JLCPCB
+    options:
+      pth_and_npth_single_file: false
+      pth_id: '-PTH'
+      npth_id: '-NPTH'
+      metric_units: true
+      map: gerber
+      route_mode_for_oval_holes: false
+      output: "%f%i.%x"
 
   - name: 'JLCPCB_position'
     comment: "Pick and place file, JLCPCB style"
@@ -96,26 +96,26 @@ outputs:
         - id: Side
           name: Layer
 
-  # - name: 'JLCPCB_bom'
-  #   comment: "BoM for JLCPCB"
-  #   type: bom
-  #   dir: JLCPCB
-  #   options:
-  #     output: '%f_%i_jlc.%x'
-  #     exclude_filter: 'only_jlc_parts'
-  #     ref_separator: ','
-  #     columns:
-  #       - field: Value
-  #         name: Comment
-  #       - field: References
-  #         name: Designator
-  #       - Footprint
-  #       - field: 'LCSC#'
-  #         name: 'LCSC Part #'
-  #     csv:
-  #       hide_pcb_info: true
-  #       hide_stats_info: true
-  #       quote_all: true
+  - name: 'JLCPCB_bom'
+    comment: "BoM for JLCPCB"
+    type: bom
+    dir: JLCPCB
+    options:
+      output: '%f_%i_jlc.%x'
+      exclude_filter: 'only_jlc_parts'
+      ref_separator: ','
+      columns:
+        - field: Value
+          name: Comment
+        - field: References
+          name: Designator
+        - Footprint
+        - field: 'LCSC#'
+          name: 'LCSC Part #'
+      csv:
+        hide_pcb_info: true
+        hide_stats_info: true
+        quote_all: true
 
   - name: JLCPCB
     comment: ZIP file for JLCPCB
@@ -129,5 +129,5 @@ outputs:
           dest: /
         - from_output: JLCPCB_position
           dest: /
-        # - from_output: JLCPCB_bom
-        #   dest: /
+        - from_output: JLCPCB_bom
+          dest: /

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -41,22 +41,7 @@ outputs:
       line_width: 0.1
       subtract_mask_from_silk: true
       inner_extension_pattern: '.gp%n'
-    layers:
-      # Note: a more generic approach is to use 'copper' but then the filenames
-      # are slightly different.
-      - F.Cu
-      - B.Cu
-      - In1.Cu
-      - In2.Cu
-      - In3.Cu
-      - In4.Cu
-      - In5.Cu
-      - In6.Cu
-      - F.SilkS
-      - B.SilkS
-      - F.Mask
-      - B.Mask
-      - Edge.Cuts
+    layers: 'selected'
 
   - name: JLCPCB_drill
     comment: Drill files compatible with JLCPCB

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -26,4 +26,4 @@ outputs:
       use_gerber_x2_attributes: true
       use_gerber_net_attributes: false
 
-    layers: 'all'
+    layers: 'selected'

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -1,6 +1,14 @@
 kibot:
   version: 1
 
+filters:
+  - name: only_jlc_parts
+    comment: 'Only parts with JLC code'
+    type: generic
+    include_only:
+      - column: 'LCSC#'
+        regex: '^C\d+'
+
 outputs:
   - name: 'gerbers'
     comment: "Gerbers for the ESC"
@@ -56,6 +64,7 @@ outputs:
     type: bom
     options:
       output: '%f_%i_jlc.%x'
+      exclude_filter: 'only_jlc_parts'
       ref_separator: ','
       columns:
         - field: Value

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -32,7 +32,6 @@ outputs:
     comment: "Pick and place file, JLC style"
     type: position
     options:
-      variant: rotated
       output: '%f_cpl_jlc.%x'
       format: CSV
       units: millimeters

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -59,22 +59,22 @@ outputs:
         - id: Side
           name: Layer
 
-  - name: 'bom'
-    comment: "BoM for JLC"
-    type: bom
-    options:
-      output: '%f_%i_jlc.%x'
-      exclude_filter: 'only_jlc_parts'
-      ref_separator: ','
-      columns:
-        - field: Value
-          name: Comment
-        - field: References
-          name: Designator
-        - Footprint
-        - field: 'LCSC#'
-          name: 'LCSC Part #'
-      csv:
-        hide_pcb_info: true
-        hide_stats_info: true
-        quote_all: true
+  # - name: 'bom'
+  #   comment: "BoM for JLC"
+  #   type: bom
+  #   options:
+  #     output: '%f_%i_jlc.%x'
+  #     exclude_filter: 'only_jlc_parts'
+  #     ref_separator: ','
+  #     columns:
+  #       - field: Value
+  #         name: Comment
+  #       - field: References
+  #         name: Designator
+  #       - Footprint
+  #       - field: 'LCSC#'
+  #         name: 'LCSC Part #'
+  #     csv:
+  #       hide_pcb_info: true
+  #       hide_stats_info: true
+  #       quote_all: true

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -58,18 +58,18 @@ outputs:
       - B.Mask
       - Edge.Cuts
 
-  - name: JLCPCB_drill
-    comment: Drill files compatible with JLCPCB
-    type: excellon
-    dir: JLCPCB
-    options:
-      pth_and_npth_single_file: false
-      pth_id: '-PTH'
-      npth_id: '-NPTH'
-      metric_units: true
-      map: gerber
-      route_mode_for_oval_holes: false
-      output: "%f%i.%x"
+  # - name: JLCPCB_drill
+  #   comment: Drill files compatible with JLCPCB
+  #   type: excellon
+  #   dir: JLCPCB
+  #   options:
+  #     pth_and_npth_single_file: false
+  #     pth_id: '-PTH'
+  #     npth_id: '-NPTH'
+  #     metric_units: true
+  #     map: gerber
+  #     route_mode_for_oval_holes: false
+  #     output: "%f%i.%x"
 
   - name: 'JLCPCB_position'
     comment: "Pick and place file, JLCPCB style"

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -102,7 +102,6 @@ outputs:
     dir: JLCPCB
     options:
       output: '%f_%i_jlc.%x'
-      exclude_filter: 'only_jlc_parts'
       ref_separator: ','
       columns:
         - field: Value

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -27,3 +27,47 @@ outputs:
       use_gerber_net_attributes: false
 
     layers: 'selected'
+  
+  - name: 'position'
+    comment: "Pick and place file, JLC style"
+    type: position
+    options:
+      variant: rotated
+      output: '%f_cpl_jlc.%x'
+      format: CSV
+      units: millimeters
+      separate_files_for_front_and_back: false
+      only_smd: true
+      columns:
+        - id: Ref
+          name: Designator
+        - Val
+        - Package
+        - id: PosX
+          name: "Mid X"
+        - id: PosY
+          name: "Mid Y"
+        - id: Rot
+          name: Rotation
+        - id: Side
+          name: Layer
+
+  - name: 'bom'
+    comment: "BoM for JLC"
+    type: bom
+    options:
+      output: '%f_%i_jlc.%x'
+      exclude_filter: 'only_jlc_parts'
+      ref_separator: ','
+      columns:
+        - field: Value
+          name: Comment
+        - field: References
+          name: Designator
+        - Footprint
+        - field: 'LCSC#'
+          name: 'LCSC Part #'
+      csv:
+        hide_pcb_info: true
+        hide_stats_info: true
+        quote_all: true

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -56,7 +56,6 @@ outputs:
     type: bom
     options:
       output: '%f_%i_jlc.%x'
-      exclude_filter: 'only_jlc_parts'
       ref_separator: ','
       columns:
         - field: Value

--- a/config.kibot.yaml
+++ b/config.kibot.yaml
@@ -1,0 +1,35 @@
+kibot:
+  version: 1
+
+preflight:
+  run_drc: true
+
+outputs:
+
+  - name: 'gerbers'
+    comment: "Gerbers for the ESC"
+    type: gerber
+    dir: gerberdir
+    options:
+      # generic layer options
+      exclude_edge_layer: false
+      exclude_pads_from_silkscreen: false
+      plot_sheet_reference: false
+      plot_footprint_refs: true
+      plot_footprint_values: true
+      force_plot_invisible_refs_vals: false
+      tent_vias: true
+      line_width: 0.15
+
+      # gerber options
+      use_aux_axis_as_origin: false
+      subtract_mask_from_silk: true
+      use_protel_extensions: false
+      gerber_precision: 4.5
+      create_gerber_job_file: true
+      use_gerber_x2_attributes: true
+      use_gerber_net_attributes: false
+
+    layers:
+      - 'F.Cu'
+      - 'B.Cu'

--- a/versions/v0.1/CCC_ESC.kicad_sch
+++ b/versions/v0.1/CCC_ESC.kicad_sch
@@ -9559,7 +9559,7 @@
   (symbol (lib_id "Connector:TestPoint") (at 144.78 130.81 0) (unit 1)
     (in_bom yes) (on_board yes)
     (uuid a7dbcf5d-7f15-47b8-818f-7472764a1ac7)
-    (property "Reference" "12V1" (id 0) (at 146.05 125.73 0)
+    (property "Reference" "Tp12V1" (id 0) (at 146.05 125.73 0)
       (effects (font (size 1.27 1.27)) (justify left))
     )
     (property "Value" "12V Pad" (id 1) (at 137.16 125.73 0)
@@ -11626,7 +11626,7 @@
       (reference "#PWR0137") (unit 1) (value "GND") (footprint "")
     )
     (path "/a7dbcf5d-7f15-47b8-818f-7472764a1ac7"
-      (reference "12V1") (unit 1) (value "12V Pad") (footprint "TestPoint:TestPoint_THTPad_D2.0mm_Drill1.0mm")
+      (reference "Tp12V1") (unit 1) (value "12V Pad") (footprint "TestPoint:TestPoint_THTPad_D2.0mm_Drill1.0mm")
     )
     (path "/c5bdcfd4-44ee-4a47-b511-8d607870eba8"
       (reference "C1") (unit 1) (value "10uF") (footprint "Capacitor_SMD:C_0603_1608Metric")


### PR DESCRIPTION
This GitHub workflow will automatically generate the requires files for JLPCB for every change, making it easier to keep track of it and prevents you from always having to push them yourself if asked for. I am not 100% sure if the settings are correct, so please check them. @badgineer 

As soon this has been merged you can active this workflow under "Action" if not already enabled and trigger it manually if needed via clicking on the workflow and pressing "Run workflow" (This workflow has a workflow_dispatch event trigger).

Required files for JLPCB:

- [x] Gerber
- [x] Excellon (waiting for https://github.com/INTI-CMNB/KiBot/issues/322)
- [x] BOM (waiting for https://github.com/INTI-CMNB/KiBot/issues/322)
- [x] CPL