### PR TITLE
Fix broken links to docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ or any other "replica" of IR2181
 We recently changed from XX4007 in SOD123 package to higher speed diode (US1M). Anything with 100V+ or 150V+ will work... but generally many 1kV diodes are available in common packages, so use them. High speed are preferable, but really most diodes will work...
 
 ## Supporting materials
-* Gathering motor parameters [[LINK](MOTOR_PARAM.md)]
-* MOSFET selection [[LINK](MOSFET_PARAMETERS.md)]
-* Pin mappings between MP2 and the F405 pill [[LINK](MP2_F405PILL_PINOUTS.md)]
-* MP2 assembly, testing and firmware [[LINK](PCB_ASSEMBLY_TESTING.md)]
-* MP2 bus bar methods [[LINK](HIGHER_AMP_ASSEMBLY.md)]
-* MESC Firmware on the MP2 -- getting started with STM32CubeIDE [[LINK](FIRMWARE_INTRO.md)]
-* Some (bad) examples of connecting the MP2 to a motor [[LINK](QS165_MP2_WIRING.md)]
+* Gathering motor parameters [[LINK](docs/MOTOR_PARAM.md)]
+* MOSFET selection [[LINK](docs/MOSFET_PARAMETERS.md)]
+* Pin mappings between MP2 and the F405 pill [[LINK](docs/MP2_F405PILL_PINOUTS.md)]
+* MP2 assembly, testing and firmware [[LINK](docs/PCB_ASSEMBLY_TESTING.md)]
+* MP2 bus bar methods [[LINK](docs/HIGHER_AMP_ASSEMBLY.md)]
+* MESC Firmware on the MP2 -- getting started with STM32CubeIDE [[LINK](docs/FIRMWARE_INTRO.md)]
+* Some (bad) examples of connecting the MP2 to a motor [[LINK](docs/QS165_MP2_WIRING.md)]
 
 ## FAQ
 

--- a/docs/PCB_ASSEMBLY_TESTING.md
+++ b/docs/PCB_ASSEMBLY_TESTING.md
@@ -35,7 +35,7 @@ Use precision:
 <img src="../gh_assets/PCB_ASSEMBLY05.png" title="watch out for components">
 <img src="../gh_assets/PCB_ASSEMBLY06.png" title="watch out for solder bridges">
 
-**NOTE:** These pics are included to talk about soldering issues, **BUT BE ADVISED WE STRONGLY RECOMMEND** users take advantage of the three holes on each phase to solder in larger wires and get improved current sharing with the MOSFETs. A better example is shown here [[LINK](../gh_assets/HIGH_AMP_EXAMPLE02.jpeg)] and take a look at [THIS FUTURE DOCUMENTATION] for other higher amperage connections. 
+**NOTE:** These pics are included to talk about soldering issues, **BUT BE ADVISED WE STRONGLY RECOMMEND** users take advantage of the three holes on each phase to solder in larger wires and get improved current sharing with the MOSFETs. A better example is shown here [[LINK](../gh_assets/HIGH_AMP_ASSEMBLY02.jpeg)] and take a look at [THIS FUTURE DOCUMENTATION] for other higher amperage connections. 
 
 <img src="../gh_assets/PCB_ASSEMBLY07.png" title="it aint pretty">
 


### PR DESCRIPTION
Added "docs/" to the relative path links on lines 149-155 in README.md

Just tested the fixed links in the branch, appear to be working.